### PR TITLE
gaufre: fix mobile style on websites w/ content going out of viewport

### DIFF
--- a/website/public/api/v1/gaufre.js
+++ b/website/public/api/v1/gaufre.js
@@ -166,7 +166,7 @@
         width: 100svw;
         height: 100%;
         height: 100svh;
-        margin: auto;
+        margin: 0;
       `
     }
     return `


### PR DESCRIPTION
in DS, they have a footer that makes the website have a width larger than viewport (creating horizontal scroll); this case was not handled well by the gaufre on mobile. This rather rare case is now handled and the gaufre doesn't care of the size of other content now.