### PR TITLE
gaufre: remove the beta tag from Docs

### DIFF
--- a/website/src/data/services.json
+++ b/website/src/data/services.json
@@ -36,7 +36,7 @@
     "tagline": "",
     "homepageType": "proconnect",
     "entity": "Gouvernement",
-    "beta": true,
+    "beta": false,
     "enabled": true
   },
   {


### PR DESCRIPTION
Docs is out of beta and should be marked as such in La Gaufre

https://github.com/numerique-gouv/lasuite-landingpage/issues/115